### PR TITLE
Zjw

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,9 @@
 
 
 # Dataset directories
-IMDB_COBET_PLAN_ALPHA = '~/Datasets/CoBeT/NTIRE2020'
+# IMDB_COBET_PLAN_ALPHA = '~/Datasets/CoBeT/NTIRE2020'
+
+IMDB_COBET_PLAN_ALPHA = '/home/linmanhui/Datasets/CoBeT/NTIRE2020'
 
 # Checkpoint templates
 CKP_LATEST = 'checkpoint_latest.pth'

--- a/src/data/NTIRE2020.py
+++ b/src/data/NTIRE2020.py
@@ -15,10 +15,8 @@ class NTIRE2020Dataset(SEDataset):
         mode=3, 
         track=1
     ):
+        self.track = str(track)
         super().__init__(root, phase, transforms, repeats, mode)
-
-    def _set_attributes(self, ctx):
-        self.track = str(ctx['track'])
 
     def _read_file_paths(self):
         with open(join(self.root, getattr(self, 'JSON_PATTERN'+self.track).format(self.phase)), 'r') as f:

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,11 +1,13 @@
 from functools import partial
 
 import numpy as np
+import torch
 from skimage.measure import compare_psnr as psnr, compare_ssim as ssim
+from .psnr import PSNR as TENSOR_PSNR
+from .ssim import SSIM as TENSOR_SSIM
 
 
 EPSILON = 1e-10
-
 
 class AverageMeter:
     def __init__(self, callback=None):
@@ -38,19 +40,43 @@ class PSNR(AverageMeter):
     def __init__(self, **configs):
         super().__init__(callback=partial(psnr, **configs))
 
+class PSNR_TENSOR(AverageMeter):
+    __name__ = 'PSNR_TENSOR'
+    def __init__(self, **configs):
+        psnr = TENSOR_PSNR(**configs)
+        super().__init__(callback=psnr)
+
 
 class SSIM(AverageMeter):
     __name__ = 'SSIM'
     def __init__(self, **configs):
         super().__init__(callback=partial(ssim, **configs))
 
+class SSIM_TENSOR(AverageMeter):
+    __name__ = 'SSIM_TENSOR'
+    def __init__(self, **configs):
+        ssim = TENSOR_SSIM(**configs)
+        super().__init__(callback=ssim)
 
 class RMSE(AverageMeter):
     __name__ = 'RMSE'
     def __init__(self):
         super().__init__(None)
     def compute(self, x1, x2):
+        x1, x2 = x1.astype('float'), x2.astype('float')
         return np.sqrt(np.mean((x1-x2)**2))
+
+class RMSE_TENSOR(AverageMeter):
+    __name__ = 'RMSE_TENSOR'
+    def __init__(self):
+        super().__init__(None)
+    def compute(self, x1, x2):
+        assert x1.shape != 4, 'Input images must 4-d tensor.'
+        assert x1.type() == x2.type(), 'Input images must 4-d tensor.'
+        assert x1.shape == x2.shape, 'Input images must have the same dimensions.'
+        x1, x2 = x1.type(torch.float), x2.type(torch.float)
+
+        return torch.mean(torch.sqrt(torch.mean((x1 - x2)**2, dim=[1, 2, 3])))
 
 
 # Adapted from
@@ -86,3 +112,138 @@ class MRAE(AverageMeter):
         super().__init__(None)
     def compute(self, predicted, actual):
         return np.mean(np.abs(_relative_error(actual, predicted, None)))
+
+def _naive_forecasting_tensor(actual, seasonality = 1):
+    """ Naive forecasting method which just repeats previous samples """
+    return actual[:, :, :-seasonality]
+
+
+def _relative_error_tensor(actual, predicted, benchmark = None):
+    """ Relative Error """
+    if benchmark is None or isinstance(benchmark, int):
+        # If no benchmark prediction provided - use naive forecasting
+        if not isinstance(benchmark, int):
+            seasonality = 1
+        else:
+            seasonality = benchmark
+        return _error(actual[:, :, seasonality:], predicted[:, :, seasonality:]) /\
+               (_error(actual[:, :, seasonality:], _naive_forecasting_tensor(actual, seasonality)) + EPSILON)
+
+    return _error(actual, predicted) / (_error(actual, benchmark) + EPSILON)
+
+
+class MRAE_TENSOR(AverageMeter):
+    __name__ = 'MRAE_TENSOR'
+    def __init__(self):
+        super().__init__(None)
+    def compute(self, predicted, actual):
+        assert predicted.shape != 4, 'Input images must 4-d tensor.'
+        assert predicted.type() == actual.type(), 'Input images must 4-d tensor.'
+        assert predicted.shape == actual.shape, 'Input images must have the same dimensions.'
+        predicted, actual = predicted.type(torch.float), actual.type(torch.float)
+
+        return torch.mean(torch.abs(_relative_error_tensor(actual, predicted, None)))
+
+
+
+
+if __name__ =='__main__':
+    from skimage import io
+    import torchvision
+    # true1 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\clear\clear\1.png')
+    # true2 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\clear\clear\2.png')
+    # true3 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\clear\clear\3.png')
+    # img1 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\hazy\hazy\1_1_0.90179.png')
+    # img2 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\hazy\hazy\2_1_0.99082.png')
+    # img3 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\hazy\hazy\3_1_0.88255.png')
+
+    true1 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\clear\clear\1.png').astype(np.float)/255
+    true2 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\clear\clear\2.png').astype(np.float)/255
+    true3 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\clear\clear\3.png').astype(np.float)/255
+    img1 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\hazy\hazy\1_1_0.90179.png').astype(np.float)/255
+    img2 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\hazy\hazy\2_1_0.99082.png').astype(np.float)/255
+    img3 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\hazy\hazy\3_1_0.88255.png').astype(np.float)/255
+
+    psnr = PSNR()
+    ssim = SSIM(multichannel=True)
+    mrae = MRAE()
+    rmse = RMSE()
+
+    psnr.update(true1, img1)
+    ssim.update(true1, img1)
+    mrae.update(true1, img1)
+    rmse.update(true1, img1)
+
+    description1 = 'numpy_version  PSNR:{} SSIM{} MRAE{} RMSE{}'.format(psnr.val, ssim.val, mrae.val, rmse.val)
+    print(description1)
+
+
+
+
+    # data_range 0-1
+    np2tensor = torchvision.transforms.ToTensor()
+    true1_t = np2tensor(true1).unsqueeze(0)
+    img1_t = np2tensor(img1).unsqueeze(0)
+    true2_t = np2tensor(true2).unsqueeze(0)
+    img2_t = np2tensor(img2).unsqueeze(0)
+    true3_t = np2tensor(true3).unsqueeze(0)
+    img3_t = np2tensor(img3).unsqueeze(0)
+
+    # data_range 0-255
+    # true1_t = torch.Tensor(true1).permute(2, 0, 1).unsqueeze(0)
+    # img1_t = torch.Tensor(img1).permute(2, 0, 1).unsqueeze(0)
+    # true2_t = torch.Tensor(true2).permute(2, 0, 1).unsqueeze(0)
+    # img2_t = torch.Tensor(img2).permute(2, 0, 1).unsqueeze(0)
+    # true3_t = torch.Tensor(true3).permute(2, 0, 1).unsqueeze(0)
+    # img3_t = torch.Tensor(img3).permute(2, 0, 1).unsqueeze(0)
+
+    true_batch = torch.cat((true1_t, true2_t, true3_t))
+    img_batch = torch.cat((img1_t, img2_t, img3_t))
+
+    psnr_t = PSNR_TENSOR(data_range=1)
+    ssim_t = SSIM_TENSOR(data_range=1)
+    mrae_t = MRAE_TENSOR()
+    rmse_t = RMSE_TENSOR()
+
+    psnr_t.update(true1_t, img1_t)
+    ssim_t.update(true1_t, img1_t)
+    mrae_t.update(true1_t, img1_t)
+    rmse_t.update(true1_t, img1_t)
+
+    description2 = 'tensor_version  PSNR:{} SSIM{} MRAE{} RMSE{}'.format(psnr_t.val, ssim_t.val, mrae_t.val, rmse_t.val)
+    print(description2)
+
+    psnr.update(true2, img2)
+    ssim.update(true2, img2)
+    mrae.update(true2, img2)
+    rmse.update(true2, img2)
+
+    psnr.update(true3, img3)
+    ssim.update(true3, img3)
+    mrae.update(true3, img3)
+    rmse.update(true3, img3)
+
+    description3 = 'numpy_batch_version  PSNR:{} SSIM{} MRAE{} RMSE{}'.format(psnr.avg, ssim.avg, mrae.avg, rmse.avg)
+    print(description3)
+
+    psnr_t.reset()
+    ssim_t.reset()
+    mrae_t.reset()
+    rmse_t.reset()
+
+    psnr_t.update(true_batch, img_batch)
+    ssim_t.update(true_batch, img_batch)
+    mrae_t.update(true_batch, img_batch)
+    rmse_t.update(true_batch, img_batch)
+
+    description4 = 'tensor_batch_version  PSNR:{} SSIM{} MRAE{} RMSE{}'.format(psnr_t.val, ssim_t.val, mrae_t.val, rmse_t.val)
+    print(description4)
+
+
+
+
+
+
+
+
+

--- a/src/utils/psnr.py
+++ b/src/utils/psnr.py
@@ -1,0 +1,51 @@
+import torch
+
+class PSNR:
+
+    def __init__(self, data_range=255):
+        self.data_range = data_range
+
+    def __call__(self, X, Y, data_range=None):
+        if data_range is None:
+            data_range = self.data_range
+
+        if len(X.shape) != 4:
+            raise ValueError('Input images must 4-d tensor.')
+
+        if not X.type() == Y.type():
+            raise ValueError('Input images must have the same dtype.')
+
+        if not X.shape == Y.shape:
+            raise ValueError('Input images must have the same dimensions.')
+
+
+
+        return self.calculate_psnr(X, Y, data_range).item()
+
+    def calculate_psnr(self, X, Y, data_range):
+        X, Y = X.type(torch.float), Y.type(torch.float)
+        mse = torch.mean((X-Y)**2, dim=[1,2,3])
+        psnr = 10 * torch.log10(data_range**2 / mse)
+        psnr = torch.mean(psnr)
+        return psnr
+
+
+if __name__ == '__main__':
+    """
+    from metric import PSNR_NP
+    from torchvision import transforms
+    img1 = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\clear\clear\1.png')
+    img1_haze = io.imread(r'F:\datasets\RESIDE-standard\ITS_v2\hazy\hazy\1_1_0.90179.png')
+    from skimage import io
+
+    psnr_np = PSNR_NP()
+    psnr_np.update(img1, img1_haze)
+    print(psnr_np.val)
+
+    totensor = transforms.ToTensor()
+    img1 = totensor(img1).unsqueeze(0)
+    img1_haze = totensor(img1_haze).unsqueeze(0)
+
+    psnr = PSNR(data_range=1)
+    print(psnr(img1, img1_haze))
+    """

--- a/src/utils/ssim.py
+++ b/src/utils/ssim.py
@@ -1,0 +1,166 @@
+import torch
+import torch.nn.functional as F
+"""
+Adapted from https://github.com/VainF/pytorch-msssim
+"""
+
+def _fspecial_gauss_1d(size, sigma):
+    coords = torch.arange(size).to(dtype=torch.float)
+    coords -= size // 2
+    g = torch.exp(-(coords ** 2) / (2 * sigma ** 2))
+    g /= g.sum()
+    return g.unsqueeze(0).unsqueeze(0)
+
+
+def gaussian_filter(input, win):
+    N, C, H, W = input.shape
+    out = F.conv2d(input, win, stride=1, padding=0, groups=C)
+    out = F.conv2d(out, win.transpose(2, 3), stride=1, padding=0, groups=C)
+    return out
+
+
+def _ssim(X, Y, win, data_range=255, size_average=True, full=False):
+    K1 = 0.01
+    K2 = 0.03
+    batch, channel, height, width = X.shape
+    compensation = 1.0
+    C1 = (K1 * data_range) ** 2
+    C2 = (K2 * data_range) ** 2
+
+    win = win.to(X.device, dtype=X.dtype)
+
+    mu1 = gaussian_filter(X, win)
+    mu2 = gaussian_filter(Y, win)
+
+    mu1_sq = mu1.pow(2)
+    mu2_sq = mu2.pow(2)
+    mu1_mu2 = mu1 * mu2
+
+    sigma1_sq = compensation * (gaussian_filter(X * X, win) - mu1_sq)
+    sigma2_sq = compensation * (gaussian_filter(Y * Y, win) - mu2_sq)
+    sigma12 = compensation * (gaussian_filter(X * Y, win) - mu1_mu2)
+
+    cs_map = (2 * sigma12 + C2) / (sigma1_sq + sigma2_sq + C2)
+    ssim_map = ((2 * mu1_mu2 + C1) / (mu1_sq + mu2_sq + C1)) * cs_map
+
+    if size_average:
+        ssim_val = ssim_map.mean()
+        cs = cs_map.mean()
+    else:
+        ssim_val = ssim_map.mean(-1).mean(-1).mean(-1)  # reduce along CHW
+        cs = cs_map.mean(-1).mean(-1).mean(-1)
+
+    if full:
+        return ssim_val, cs
+    else:
+        return ssim_val
+
+
+def ssim(X, Y, win_size=11, win_sigma=10, win=None, data_range=1, size_average=True, full=False):
+    if len(X.shape) != 4:
+        raise ValueError('Input images must 4-d tensor.')
+
+    if not X.type() == Y.type():
+        raise ValueError('Input images must have the same dtype.')
+
+    if not X.shape == Y.shape:
+        raise ValueError('Input images must have the same dimensions.')
+
+    if not (win_size % 2 == 1):
+        raise ValueError('Window size must be odd.')
+
+    win_sigma = win_sigma
+    if win is None:
+        win = _fspecial_gauss_1d(win_size, win_sigma)
+        win = win.repeat(X.shape[1], 1, 1, 1)
+    else:
+        win_size = win.shape[-1]
+
+    ssim_val, cs = _ssim(X, Y,
+                         win=win,
+                         data_range=data_range,
+                         size_average=False,
+                         full=True)
+    if size_average:
+        ssim_val = ssim_val.mean()
+        cs = cs.mean()
+
+    if full:
+        return ssim_val, cs
+    else:
+        return ssim_val
+
+
+def ms_ssim(X, Y, win_size=11, win_sigma=10, win=None, data_range=1, size_average=True, full=False, weights=None):
+    if len(X.shape) != 4:
+        raise ValueError('Input images must 4-d tensor.')
+
+    if not X.type() == Y.type():
+        raise ValueError('Input images must have the same dtype.')
+
+    if not X.shape == Y.shape:
+        raise ValueError('Input images must have the same dimensions.')
+
+    if not (win_size % 2 == 1):
+        raise ValueError('Window size must be odd.')
+
+    if weights is None:
+        weights = torch.FloatTensor([0.0448, 0.2856, 0.3001, 0.2363, 0.1333]).to(X.device, dtype=X.dtype)
+
+    win_sigma = win_sigma
+    if win is None:
+        win = _fspecial_gauss_1d(win_size, win_sigma)
+        win = win.repeat(X.shape[1], 1, 1, 1)
+    else:
+        win_size = win.shape[-1]
+
+    levels = weights.shape[0]
+    mcs = []
+    for _ in range(levels):
+        ssim_val, cs = _ssim(X, Y,
+                             win=win,
+                             data_range=data_range,
+                             size_average=False,
+                             full=True)
+        mcs.append(cs)
+
+        padding = (X.shape[2] % 2, X.shape[3] % 2)
+        X = F.avg_pool2d(X, kernel_size=2, padding=padding)
+        Y = F.avg_pool2d(Y, kernel_size=2, padding=padding)
+
+    mcs = torch.stack(mcs, dim=0)  # mcs, (level, batch)
+    # weights, (level)
+    msssim_val = torch.prod((mcs[:-1] ** weights[:-1].unsqueeze(1))
+                            * (ssim_val ** weights[-1]), dim=0)  # (batch, )
+
+    if size_average:
+        msssim_val = msssim_val.mean()
+    return msssim_val
+
+
+# Classes to re-use window
+class SSIM(torch.nn.Module):
+    def __init__(self, win_size=7, win_sigma=1.5, data_range=255, size_average=True, channel=3):
+        super(SSIM, self).__init__()
+        self.win = _fspecial_gauss_1d(
+            win_size, win_sigma).repeat(channel, 1, 1, 1)
+        self.size_average = size_average
+        self.data_range = data_range
+
+    def forward(self, X, Y):
+        return ssim(X, Y, win=self.win, data_range=self.data_range, size_average=self.size_average)
+
+
+class MS_SSIM(torch.nn.Module):
+    def __init__(self, win_size=7, win_sigma=1.5, data_range=255, size_average=True, channel=3, weights=None):
+        super(MS_SSIM, self).__init__()
+        self.win = _fspecial_gauss_1d(
+            win_size, win_sigma).repeat(channel, 1, 1, 1)
+        self.size_average = size_average
+        self.data_range = data_range
+        self.weights = weights
+
+    def forward(self, X, Y):
+        return ms_ssim(X, Y, win=self.win, size_average=self.size_average, data_range=self.data_range,
+                       weights=self.weights)
+


### PR DESCRIPTION
1 将tensorboard整合到了logger内部，以代理的方式运行；tensorboard的add_image功能实测存在一些缺陷，貌似存在存储的上限，现在还不知道怎么解决。
运行方法： 使用xshell监听tensorboard解析的服务器端口，然后在本地浏览器打开对应端口。

2增加了tensor版本的metrics，并且修复了原numpy版本中输入uint8会溢出的bug，两种版本的实验如下：
0-255版本
```
numpy_version  PSNR:12.373782512869063 SSIM0.7796075983206711 MRAE181564504429.2188 RMSE61.3551546041055
tensor_version  PSNR:12.373963356018066 SSIM0.7883440852165222 MRAE180135198720.0 RMSE61.35387420654297
numpy_batch_version  PSNR:13.557796327286036 SSIM0.8176813834973631 MRAE185538989243.10852 RMSE56.153522349359456
tensor_batch_version  PSNR:13.558379173278809 SSIM0.8246926665306091 MRAE171272585216.0 RMSE56.1500244140625
```
0-1版本
```
numpy_version  PSNR:12.373782512869063 SSIM0.8059546694505935 MRAE706412640.1305474 RMSE0.24060844942786475
tensor_version  PSNR:12.373804092407227 SSIM0.7883396001579656 MRAE706413184.0 RMSE0.2406078577041626
numpy_batch_version  PSNR:13.557796327286036 SSIM0.8396552481420638 MRAE671652470.1232511 RMSE0.22020989156611556
tensor_batch_version  PSNR:13.557716369628906 SSIM0.8246875638024047 MRAE671657024.0 RMSE0.22021199762821198；
```
个人觉得skimage版的ssim是有点问题，0-1和0-255的差别很大。 除此之外的，与原来的metrics的使用在于初始化参数做了改变，改变如下：
```
#metrics: SSIM+PSNR+RMSE
metrics: SSIM_TENSOR+PSNR_TENSOR+RMSE_TENSOR
#  - multichannel: True
#    data_range: 1.0
  - channel: 3
    data_range: 1.0
```
3除此之外在trainers中增添了直接存储tensor图像的方法。