### PR TITLE
Zjw

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -3,7 +3,6 @@
 
 # Dataset directories
 # IMDB_COBET_PLAN_ALPHA = '~/Datasets/CoBeT/NTIRE2020'
-
 IMDB_COBET_PLAN_ALPHA = '/home/linmanhui/Datasets/CoBeT/NTIRE2020'
 
 # Checkpoint templates

--- a/src/core/factories.py
+++ b/src/core/factories.py
@@ -310,6 +310,9 @@ def metric_factory(metric_names, C):
 
 if __name__ == '__main__':
     fake_model = DuckModel(nn.Conv2d(3,3,3), nn.Conv2d(3,3,3))
+    temp = torch.Tensor(1,2,3,4)
+    # output = fake_model(temp)
+    print(getmembers(fake_model))
     fake_model.load_state_dict(fake_model.state_dict())
     optim = torch.optim.Adam(fake_model.parameters(), 
                             betas=(0.9,0.999), 
@@ -320,15 +323,15 @@ if __name__ == '__main__':
 
     fake_criterion = DuckCriterion(nn.L1Loss(), nn.CrossEntropyLoss())
 
-    from data.BSDS500 import BSDS500Dataset
-    fake_dataset = DuckDataset(BSDS500Dataset('~/Datasets/BSR/'), BSDS500Dataset('~/Datasets/BSR/'))
-    loader = torch.utils.data.DataLoader(fake_dataset)
-
-    for param_group in fake_optim.param_groups:
-        param_group['lr'] = 0.1
-    
-    fake_criterion.to('cpu')
-    print(fake_model._version)
-    fake_model._version = (0.5, 0.5)
-    print(fake_model._version)
-    fake_model._version = {0.5, 0.9}
+    # from data.BSDS500 import BSDS500Dataset
+    # fake_dataset = DuckDataset(BSDS500Dataset('~/Datasets/BSR/'), BSDS500Dataset('~/Datasets/BSR/'))
+    # loader = torch.utils.data.DataLoader(fake_dataset)
+    #
+    # for param_group in fake_optim.param_groups:
+    #     param_group['lr'] = 0.1
+    #
+    # fake_criterion.to('cpu')
+    # print(fake_model._version)
+    # fake_model._version = (0.5, 0.5)
+    # print(fake_model._version)
+    # fake_model._version = {0.5, 0.9}

--- a/src/core/predictors.py
+++ b/src/core/predictors.py
@@ -1,0 +1,248 @@
+import torch
+import torchvision
+import os
+from torchvision import transforms
+from utils.metrics import AverageMeter
+from utils.misc import Logger
+import time
+import glob
+from skimage import io
+import numpy as np
+from tqdm import tqdm
+from functools import partial
+from utils.data_utils import to_tensor, to_array, normalize
+import hdf5storage as hdf5
+"""
+输入：
+可以是dataloader,可以是文件夹， 可以是装有文件路径的列表， 可以是单张文件的路径，可以是张量
+
+"""
+
+class Predictor:
+    modes = ['dataloader', 'folder', 'list', 'file', 'data']
+    def __init__(self, model=None, mode='folder', save_dir=None, scrn=True, log_dir=None, cuda_off=False):
+
+        self.save_dir = save_dir
+        self.output = None
+
+        if not cuda_off and torch.cuda.is_available():
+            self.device = torch.device('cuda')
+        else:
+            self.device = torch.device('cpu')
+
+        assert  model is not None, "The model must be assigned"
+        self.model = self._model_init(model)
+
+
+        if mode not in Predictor.modes:
+            raise NotImplementedError
+
+        self.logger = Logger(scrn=scrn, log_dir=log_dir, phase='predict')
+
+        if mode == 'dataloader':
+            self.predict = partial(self._predict_dataloader, dataloader=None, save_dir=save_dir)
+        elif mode == 'folder':
+            # self.suffix = ['.jpg', '.png', '.bmp', '.gif', '.npy']  # 支持的图像格式
+            self.predict = partial(self._predict_folder, save_dir=save_dir)
+        elif mode == 'list':
+            self.predict = partial(self._predict_list, save_dir=save_dir)
+        elif mode == 'file':
+            self.predict = partial(self._predict_file, save_dir=save_dir)
+        elif mode == 'data':
+            self.predict = partial(self._predict_data, save_dir=save_dir)
+        else:
+            raise NotImplementedError
+
+    def __call__(self, *args, **kwargs):
+        return self.predict(*args, **kwargs)
+
+
+    def _model_init(self, model):
+        model.to(self.device)
+        model.eval()
+        return model
+
+    def _load_data(self, path):
+        return io.imread(path)
+
+    def _to_tensor(self, arr):
+        return to_tensor(arr)
+
+    def _to_array(self, tensor):
+        return  to_array(tensor)
+
+    def _normalize(self, tensor):
+        return normalize(tensor)
+
+    def _np2tensor(self, arr):
+        nor_tensor = self._normalize(self._to_tensor(arr))
+        assert isinstance(nor_tensor, torch.Tensor)
+        return nor_tensor
+
+    def _save_data_NTIRE2020(self, data, path):
+        s_dir = os.path.dirname(path)
+        if not os.path.exists(s_dir):
+            os.mkdir(s_dir)
+        path = path.replace('_clean.png', '.mat').replace('_RealWorld.png', '.mat')
+        if isinstance(data, torch.Tensor):
+            data = self._to_array(data).squeeze()
+
+        content = {}
+        content['cube'] = data
+        content['bands'] = np.array([[400, 410, 420, 430, 440, 450, 460, 470, 480, 490, 500, 510, 520,
+        530, 540, 550, 560, 570, 580, 590, 600, 610, 620, 630, 640, 650,
+        660, 670, 680, 690, 700]])
+        # content['norm_factor'] =
+        hdf5.write(data=content, filename=path, store_python_metadata=True, matlab_compatible=True)
+
+
+    def _save_data(self, data, path):
+        s_dir = os.path.dirname(path)
+        if not os.path.exists(s_dir):
+            os.mkdir(s_dir)
+
+        torchvision.utils.save_image(data, path)
+
+    def predict_base(self, model, data, path=None):
+        start = time.time()
+        with torch.no_grad():
+            output = model(data)
+        torch.cuda.synchronize()
+        su_time = time.time() - start
+        if path:
+            self._save_data_NTIRE2020(output, path)
+
+        self.output = output
+        return output, su_time
+
+
+    def _predict_dataloader(self, dataloader, save_dir=None):
+        assert dataloader is not None, \
+            "In 'dataloader' mode the input must be a valid dataloader!"
+        consume_time = AverageMeter()
+        pb = tqdm(dataloader)
+        for idx, (name, data) in enumerate(pb):
+            assert isinstance(data, torch.Tensor) and data.dim() == 4,\
+            "input data must be 4-dimention tensor"
+            data = data.to(self.device) # 4-d tensor
+            save_path = os.path.join(save_dir, name) if save_dir else None
+            _, su_time = self.predict_base(self.model, data, path=save_path)
+            consume_time.update(su_time, n=1)
+
+            # logger
+            description = ("[{}/{}] speed: {time.val:.4f}s({time.avg:.4f}s)".
+                           format(idx+1, len(dataloader.dataset), time=consume_time))
+            pb.set_description(description)
+            self.logger.dump(description)
+
+
+    def _predict_folder(self, folder, save_dir=None):
+        assert folder is not None and os.path.isdir(folder),\
+        "In 'folder' mode the input must be a valid path of a folder!"
+        consume_time = AverageMeter()
+        file_list = glob.glob(os.path.join(folder, '*'))
+
+        assert not len(file_list) == 0, "The input folder is empty"
+
+        pb = tqdm(file_list)    # processbar
+
+        for idx, file in enumerate(pb):
+            img = self._load_data(file)
+            name = os.path.basename(file)
+            img = self._np2tensor(img).unsqueeze(0).to(self.device)
+            save_path = os.path.join(save_dir, name) if save_dir else None
+            _, su_time = self.predict_base(model=self.model, data=img, path=save_path)
+            consume_time.update(su_time)
+
+            # logger
+            description = ("[{}/{}] speed: {time.val:.4f}s({time.avg:.4f}s)".
+                           format(idx + 1, len(file_list), time=consume_time))
+            pb.set_description(description)
+            self.logger.dump(description)
+
+
+    def _predict_list(self, file_list, save_dir=None):
+        assert isinstance(file_list, list),\
+        "In 'list' mode the input must be a valid file_path list!"
+        consume_time = AverageMeter()
+
+        assert not len(file_list) == 0, "The input file list is empty!"
+
+        pb = tqdm(file_list)    # processbar
+
+        for idx, path in enumerate(pb):
+            data = self._load_data(path)
+            name = os.path.basename(path)
+            data = self._np2tensor(data).unsqueeze(0).to(self.device)
+            path = os.path.join(save_dir, name) if save_dir else None
+            _, su_time = self.predict_base(model=self.model, data=data, path=path)
+            consume_time.update(su_time, n=1)
+
+            # logger
+            description = ("[{}/{}] speed: {time.val:.4f}s({time.avg:.4f}s)".
+                           format(idx + 1, len(file_list), time=consume_time))
+            pb.set_description(description)
+            self.logger.dump(description)
+
+
+    def _predict_file(self, file_path, save_dir=None):
+        assert isinstance(file_path, str) and os.path.isfile(file_path), \
+        "In 'file' mode the input must a valid path of a file!"
+
+        consume_time = AverageMeter()
+        data = self._load_data(file_path)
+        name = os.path.basename(file_path)
+        data = self._np2tensor(data).unsqueeze(0).to(self.device)
+        path = os.path.join(save_dir, name) if save_dir else None
+
+        _, su_time = self.predict_base(model=self.model, data=data, path=path)
+        consume_time.update(su_time)
+
+        # logger
+        description = ("file: {}  speed: {time.val:.4f}s".
+                       format(name, time=consume_time))
+
+        self.logger.show(description)
+
+
+    def _predict_data(self, data):
+        """
+        :return: tensor
+        """
+
+        assert isinstance(data, torch.Tensor) and data.dim() == 4, \
+        "In 'data' mode the input must be a 4-d tensor"
+
+        consume_time = AverageMeter()
+        output, su_time = self.predict_base(model=self.model, data=data)
+
+        consume_time.update(su_time)
+
+        # logger
+        description = ("speed: {time.val:.4f}s".format(time=consume_time))
+
+        self.logger.dump(description)
+
+        return output
+
+
+
+
+if __name__ == '__main__':
+    pass
+    # from models.ddnet import  DDnet
+    #
+    # model = DDnet(n_channels=3, bilinear=False)
+    # state_dict = torch.load(r'snapshots/3-epoch.pt')
+    # model.load_state_dict(state_dict['model_state_dict'])
+    # img2tensor = transforms.ToTensor()
+    #
+    # img = io.imread(r'../datasets/DDnet/test/haze/SOTS-indoor_1400_1.png')
+    # # img = img2tensor(img)
+    # predictor = Predictor(input=r'../datasets/DDnet/test/haze/', mode='folder', model=model, save_dir='../datasets/DDnet/test/result', scrn=True)
+    # data = predictor.predict()
+    # print(data)
+
+
+
+

--- a/src/core/predictors.py
+++ b/src/core/predictors.py
@@ -40,21 +40,21 @@ class Predictor:
         self.logger = Logger(scrn=scrn, log_dir=log_dir, phase='predict')
 
         if mode == 'dataloader':
-            self.predict = partial(self._predict_dataloader, dataloader=None, save_dir=save_dir)
+            self._predict = partial(self._predict_dataloader, dataloader=None, save_dir=save_dir)
         elif mode == 'folder':
             # self.suffix = ['.jpg', '.png', '.bmp', '.gif', '.npy']  # 支持的图像格式
-            self.predict = partial(self._predict_folder, save_dir=save_dir)
+            self._predict = partial(self._predict_folder, save_dir=save_dir)
         elif mode == 'list':
-            self.predict = partial(self._predict_list, save_dir=save_dir)
+            self._predict = partial(self._predict_list, save_dir=save_dir)
         elif mode == 'file':
-            self.predict = partial(self._predict_file, save_dir=save_dir)
+            self._predict = partial(self._predict_file, save_dir=save_dir)
         elif mode == 'data':
-            self.predict = partial(self._predict_data, save_dir=save_dir)
+            self._predict = partial(self._predict_data, save_dir=save_dir)
         else:
             raise NotImplementedError
 
     def __call__(self, *args, **kwargs):
-        return self.predict(*args, **kwargs)
+        return self._predict(*args, **kwargs)
 
 
     def _model_init(self, model):

--- a/src/core/trainers.py
+++ b/src/core/trainers.py
@@ -2,7 +2,6 @@ import shutil
 import os
 from types import MappingProxyType
 from copy import deepcopy
-
 import torch
 import torchvision
 from skimage import io
@@ -232,8 +231,8 @@ class EstimatorTrainer(Trainer):
         # # @zjw: tensorboard
         # self.writer = SummaryWriter(log_dir=settings.tensorboard_dir, comment='_Estimator')  # default dir: ./runs/
 
-    def __del__(self):
-        hasattr(self, 'writer') and self.writer.close()
+    # def __del__(self):
+    #     hasattr(self, 'writer') and self.writer.close()
 
     def train_epoch(self, epoch=0):
         losses = AverageMeter()
@@ -377,8 +376,8 @@ class ClassifierTrainer(Trainer):
         # # @zjw: tensorboard
         # self.writer = SummaryWriter(log_dir=settings.tensorboard_dir, comment='_Classifier')  # default dir: ./runs/
 
-    def __del__(self):
-        hasattr(self, 'writer') and self.writer.close()
+    # def __del__(self):
+    #     hasattr(self, 'writer') and self.writer.close()
 
     def train_epoch(self, epoch=0):
         losses = AverageMeter()
@@ -490,8 +489,8 @@ class SolverTrainer(Trainer):
         # # @zjw: tensorboard
         # self.writer = SummaryWriter(log_dir=settings.tensorboard_dir, comment='_Solver')  # default dir: ./runs/
 
-    def __del__(self):
-        hasattr(self, 'writer') and self.writer.close()
+    # def __del__(self):
+    #     hasattr(self, 'writer') and self.writer.close()
 
     def train_epoch(self, epoch=0):
         losses = AverageMeter()

--- a/src/models/conditional.py
+++ b/src/models/conditional.py
@@ -1,9 +1,5 @@
 import torch
 import torch.nn as nn
-import sys
-import os
-# print(os.path.dirname(__file__))
-sys.path.append(os.path.join(os.path.dirname(__file__), 'models'))
 from models.estimator import Estimator
 from models.residual_hyper_inference import ResidualHyperInference
 

--- a/src/models/conditional.py
+++ b/src/models/conditional.py
@@ -1,0 +1,33 @@
+import torch
+import torch.nn as nn
+import sys
+import os
+# print(os.path.dirname(__file__))
+sys.path.append(os.path.join(os.path.dirname(__file__), 'models'))
+from models.estimator import Estimator
+from models.residual_hyper_inference import ResidualHyperInference
+
+class Conditional(nn.Module):
+    def __init__(self, n_in, n_out, n_resblocks):
+        super().__init__()
+        self.estimator = Estimator(n_in, 93)
+        self.residual_hyper_inference = ResidualHyperInference(96, n_out, n_resblocks)
+
+    def load_checkpoint(self, *state_dict):
+        self.estimator.load_state_dict(state_dict[0])
+        self.residual_hyper_inference.load_state_dict(state_dict[1])
+
+    def forward(self, x):
+        sens = self.estimator(x)    # (31, 3)
+        x = torch.cat([x, sens.view(1, -1, 1, 1).repeat(x.size(0), 1, *x.shape[2:])], dim=1)    #(x, 96, ?,?)
+        y = self.residual_hyper_inference(x)
+
+        return y
+
+
+
+if __name__ == '__main__':
+    model = Conditional(3, 31, 2)
+    temp = torch.Tensor(3, 3, 256, 256)
+    output = model(temp)
+    print(output.shape)

--- a/src/models/estimator.py
+++ b/src/models/estimator.py
@@ -1,8 +1,8 @@
 import torch
 import torch.nn as nn
 
+# from .common import SameConv3x3, SameConv5x5, MaxPool2x2
 from .common import SameConv3x3, SameConv5x5, MaxPool2x2
-
 
 __ENTRANCE__ = 'Estimator'
 
@@ -61,4 +61,11 @@ class Estimator(nn.Module):
 
         c = y.size(1)
         y = y.mean(0).view(c, -1).mean(-1)
-        return y.view(*self.out_shape)
+        return y.view(*self.out_shape)  # (31, 3)
+
+
+if __name__ == '__main__':
+    temp = torch.Tensor(2, 3, 256, 256)
+    model = Estimator(3, 93)
+    output = model(temp)
+    print(output.shape)

--- a/src/models/residual_hyper_inference.py
+++ b/src/models/residual_hyper_inference.py
@@ -74,3 +74,10 @@ class ResidualHyperInference(nn.Module):
         x = self.conv_expand(x)
 
         return self.conv_out(x) + self.upsample(x_)[...,self.cut:-self.cut, self.cut:-self.cut]
+
+
+if __name__ == '__main__':
+    temp = torch.Tensor(2, 96, 256, 256)
+    model = ResidualHyperInference(96, 31, 2)
+    output = model(temp)
+    print(output.shape)

--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,97 @@
+import argparse
+import yaml
+import json
+from core.predictors import Predictor
+from models.conditional import Conditional
+# from models.classifier import Classifier
+# from models.common import BasicConv
+# from models.estimator import Estimator
+import torch
+import os
+
+
+def read_config(config_path):
+    with open(config_path, 'r') as f:
+        cfg = yaml.load(f.read(), Loader=yaml.FullLoader)
+    return cfg or {}
+
+
+def read_file_paths(json_path):
+    with open(json_path, 'r') as test:
+        rgb_list = json.load(test)
+
+    return rgb_list
+
+
+def parse_config(cfg_name, cfg):
+    # Note that no type check is yet done here!
+    # Parse the name of config file
+    sp = cfg_name.split('.')[0].split('_')
+    if len(sp) >= 2:
+        cfg.setdefault('tag', sp[1])
+        cfg.setdefault('suffix', '_'.join(sp[2:]))
+
+    # Parse metric configs
+    if 'metric_configs' in cfg:
+        cfg['metric_configs'] = tuple((dict() if c is None else c) for c in cfg['metric_configs'])
+
+    return cfg
+
+
+def parse_ckp(ckp_list):
+    assert ckp_list
+    ckps = []
+    for ckp in ckp_list:
+        checkpoint = torch.load(ckp)
+        ckp_dict = checkpoint.get('state_dict', checkpoint)
+        ckps.append(ckp_dict)
+
+    return ckps
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('solution', choices=['C', 'G', 'S'], help="C: estimator+solver; G: generic; S: classifier+solver")
+    parser.add_argument('--exp-config', type=str, default='')
+    parser.add_argument('--checkpoints', nargs='+',  help="The path of pre-trained weights for the model")
+    parser.add_argument('--json_path', default=None)
+    parser.add_argument('--save_dir', help='The directory for saving results')
+    parser.add_argument('--cuda_off', action='store_true', default=False)
+    parser.add_argument('--num_feats_in', default=3)
+    parser.add_argument('--num_feats_out', default=31)
+    parser.add_argument('--num_resblocks', default=2)
+
+    args = parser.parse_args()
+
+    if os.path.exists(args.exp_config):
+        cfg = read_config(args.exp_config)
+        print(cfg)
+        cfg = parse_config(os.path.basename(args.exp_config), cfg)
+        # Settings from cfg file overwrite those in args
+        # Note that the non-default values will not be affected
+        parser.set_defaults(**cfg)  # Reset part of the default values
+        args = parser.parse_args()  # Parse again
+
+    print(args)
+
+    if args.solution == 'C':
+        model = Conditional(args.num_feats_in, args.num_feats_out, args.num_resblocks)
+    elif args.solution == 'G':
+        pass
+    elif args.solution == 'S':
+        pass
+    else:
+        raise NotImplementedError
+
+    ckps = parse_ckp(args.checkpoints)
+    model.load_checkpoint(*ckps)
+
+    file_list = read_file_paths(args.json_path)
+
+    predictor = Predictor(model=model, mode='list', cuda_off=args.cuda_off, save_dir=args.save_dir)
+    predictor(file_list)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/src/test_conditional.py
+++ b/src/test_conditional.py
@@ -1,0 +1,8 @@
+import torch
+from models.conditional import Conditional
+
+if __name__ == '__main__':
+    model = Conditional(3, 31, 2)
+    temp = torch.Tensor(3, 3, 256, 256)
+    output = model(temp)
+    print(output.shape)

--- a/src/test_conditional.py
+++ b/src/test_conditional.py
@@ -1,8 +1,0 @@
-import torch
-from models.conditional import Conditional
-
-if __name__ == '__main__':
-    model = Conditional(3, 31, 2)
-    temp = torch.Tensor(3, 3, 256, 256)
-    output = model(temp)
-    print(output.shape)

--- a/src/train.py
+++ b/src/train.py
@@ -43,8 +43,8 @@ def parse_args():
     parser.add_argument('task', choices=['E', 'C', 'S'])
 
     # tensorboard
-    parser.add_argument('--tensorboard_dir', type=str, default=None,
-                        help="if None is given, the default dir will be './runs/CURRENT_DATETIME_HOSTNAME/' ")
+    # parser.add_argument('--tensorboard_dir', type=str, default=None,
+    #                     help="if None is given, the default dir will be './runs/CURRENT_DATETIME_HOSTNAME/' ")
 
     # Data
     # Common

--- a/src/utils/data_utils.py
+++ b/src/utils/data_utils.py
@@ -34,7 +34,7 @@ def to_array(tensor):
         raise NotImplementedError
 
 def normalize(tensor):
-    return tensor / 255.0
+    return tensor.type(torch.float32) / 255.0
 
 def denormalize(tensor):
     return tensor * 255.0


### PR DESCRIPTION
##### 1
完成了test.py的部分内容：estimarot+slover模式，这部分我采用比较暴力的方式把两个模型组合成一个新的模型；接口方面尽量和train.py保持了一致。
##### 2
增加了predictor模块，该模块接收模型和数据，预测模型的结果并保存到指定的路径中，现在采用猴子打补丁的模式，数据形式支持dataloader、list、file、data。目前在test.py中采用的方式是读入一个json然后以路径列表的形式传入predictor进行预测；
##### 3
修复了utils.data_utils.normalize方法当传入int类型时会输出0的隐患，貌似pytorch的tensor即使和一个浮点数常数运算了，也不会自动转为浮点类型。