### PR TITLE
Fix bugs in solver

### DIFF
--- a/src/models/conditional.py
+++ b/src/models/conditional.py
@@ -21,9 +21,11 @@ class Conditional(nn.Module):
         return y
 
 
-
 if __name__ == '__main__':
     model = Conditional(3, 31, 2)
     temp = torch.Tensor(3, 3, 256, 256)
+    state_dict = model.state_dict()
+    # print(state_dict)
+    print(state_dict.keys())
     output = model(temp)
     print(output.shape)

--- a/src/test.py
+++ b/src/test.py
@@ -65,7 +65,7 @@ def main():
 
     if os.path.exists(args.exp_config):
         cfg = read_config(args.exp_config)
-        print(cfg)
+        # print(cfg)
         cfg = parse_config(os.path.basename(args.exp_config), cfg)
         # Settings from cfg file overwrite those in args
         # Note that the non-default values will not be affected

--- a/src/utils/misc.py
+++ b/src/utils/misc.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from weakref import proxy
 from torch.utils.tensorboard import SummaryWriter
 
+
 FORMAT_LONG = "[%(asctime)-15s %(funcName)s] %(message)s"
 FORMAT_SHORT = "%(message)s"
 
@@ -18,7 +19,6 @@ class Logger:
         Logger._count += 1
         self._logger.setLevel(logging.DEBUG)
 
-        self._writer = SummaryWriter(log_dir=log_dir, comment='-' + phase if not phase else phase)
 
         if scrn:
             self._scrn_handler = logging.StreamHandler()
@@ -36,6 +36,11 @@ class Logger:
             self._file_handler.setLevel(logging.DEBUG)
             self._file_handler.setFormatter(logging.Formatter(fmt=FORMAT_LONG))
             self._logger.addHandler(self._file_handler)
+
+            self._writer = SummaryWriter(log_dir=os.path.join(log_dir,
+                                            '{}-{:-4d}-{:02d}-{:02d}-{:02d}-{:02d}-{:02d}'.format(
+                                                phase, *localtime()[:6])
+                                            ))
 
 
     def show(self, *args, **kwargs):

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -34,13 +34,17 @@ def create_rgb(sens, hsi):
 
     
 def construct(blocks, N):
-    blocks = torch.cat(torch.chunk(blocks, N, dim=1), dim=-1)
-    return torch.cat(torch.unbind(blocks, dim=1), dim=-2)
+    blocks = torch.cat(torch.chunk(blocks, N, dim=0), dim=-1)
+    return torch.cat(torch.chunk(blocks, N, dim=0), dim=-2)
+    # blocks = torch.cat(torch.chunk(blocks, N, dim=1), dim=-1)
+    # return torch.cat(torch.unbind(blocks, dim=1), dim=-2)
 
 
 def deconstruct(x, N):
-    blocks = torch.stack(torch.chunk(x, N, dim=-2), dim=1)
-    return torch.cat(torch.chunk(blocks, N, dim=-1), dim=1)
+    blocks = torch.cat(torch.chunk(x, N, dim=-2), dim=0)
+    return torch.cat(torch.chunk(blocks, N, dim=-1), dim=0)
+    # blocks = torch.stack(torch.chunk(x, N, dim=-2), dim=1)
+    # return torch.cat(torch.chunk(blocks, N, dim=-1), dim=1)
 
 
 # These functions below are adapted from 


### PR DESCRIPTION
1 将ResidualHyperInference中所有的普通卷积增加了padding，补上了论文中的跳连接；
2 将SolverTrainer的chop方式改成了放到batch中操作，取消了for循环；
3 将tensorboard的日志文件路径改成文件夹，方便解析